### PR TITLE
Nav codelab

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/MelAssignment3.iml
+++ b/.idea/MelAssignment3.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/MelAssignment3.iml" filepath="$PROJECT_DIR$/.idea/MelAssignment3.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/NavigationCodelab/app/build.gradle
+++ b/NavigationCodelab/app/build.gradle
@@ -97,6 +97,8 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.8.0"
     debugImplementation "androidx.compose.ui:ui-tooling"
 
+    // Navigation
+    implementation "androidx.navigation:navigation-compose:2.7.5"
     // Testing dependencies
     androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:3.5.1"

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -26,8 +26,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.*
+import androidx.navigation.navArgument
 import com.example.compose.rally.ui.accounts.AccountsScreen
+import com.example.compose.rally.ui.accounts.SingleAccountScreen
 import com.example.compose.rally.ui.bills.BillsScreen
 import com.example.compose.rally.ui.components.RallyTabRow
 import com.example.compose.rally.ui.overview.OverviewScreen
@@ -87,6 +90,17 @@ fun RallyApp() {
                 }
                 composable(route = Bills.route) {
                     BillsScreen()
+                }
+                composable(
+                    route = SingleAccount.routeWithArgs,
+                    arguments =  SingleAccount.arguments
+                ) { navBackStackEntry ->
+                    // Retrieve the passed argument
+                    val accountType =
+                        navBackStackEntry.arguments?.getString(SingleAccount.accountTypeArg)
+
+                    // Pass accountType to SingleAccountScreen
+                    SingleAccountScreen(accountType)
                 }
             }
 

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -46,8 +46,12 @@ class RallyActivity : ComponentActivity() {
 @Composable
 fun RallyApp() {
     RallyTheme {
-        var currentScreen: RallyDestination by remember { mutableStateOf(Overview) }
         val navController = rememberNavController()
+
+        val currentBackStack by navController.currentBackStackEntryAsState()
+        val currentDestination = currentBackStack?.destination
+
+        val currentScreen = rallyTabRowScreens.find { it.route == currentDestination?.route } ?: Overview
         Scaffold(
             topBar = {
                 RallyTabRow(

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -73,7 +73,14 @@ fun RallyApp() {
                 modifier = Modifier.padding(innerPadding)
             ) {
                 composable(route = Overview.route) {
-                    OverviewScreen()
+                    OverviewScreen(
+                        onClickSeeAllAccounts = {
+                            navController.navigateSingleTopTo(Accounts.route)
+                        },
+                        onClickSeeAllBills = {
+                            navController.navigateSingleTopTo(Bills.route)
+                        }
+                    )
                 }
                 composable(route = Accounts.route) {
                     AccountsScreen()

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -82,11 +82,18 @@ fun RallyApp() {
                         },
                         onClickSeeAllBills = {
                             navController.navigateSingleTopTo(Bills.route)
+                        },
+                        onAccountClick = { accountName ->
+                            navController.navigateToSingleAccount(accountName)
                         }
                     )
                 }
                 composable(route = Accounts.route) {
-                    AccountsScreen()
+                    AccountsScreen(
+                        onAccountClick = { accountType ->
+                            navController.navigateToSingleAccount(accountType)
+                        }
+                    )
                 }
                 composable(route = Bills.route) {
                     BillsScreen()
@@ -118,3 +125,8 @@ fun NavHostController.navigateSingleTopTo(route: String) =
         launchSingleTop = true
         restoreState = true
     }
+
+
+private fun NavHostController.navigateToSingleAccount(accountType: String) {
+    this.navigateSingleTopTo("${SingleAccount.route}/$accountType")
+}

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -22,12 +22,9 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.*
 import com.example.compose.rally.ui.components.RallyTabRow
 import com.example.compose.rally.ui.theme.RallyTheme
 
@@ -48,6 +45,7 @@ class RallyActivity : ComponentActivity() {
 fun RallyApp() {
     RallyTheme {
         var currentScreen: RallyDestination by remember { mutableStateOf(Overview) }
+        val navController = rememberNavController()
         Scaffold(
             topBar = {
                 RallyTabRow(
@@ -57,9 +55,23 @@ fun RallyApp() {
                 )
             }
         ) { innerPadding ->
-            Box(Modifier.padding(innerPadding)) {
-                currentScreen.screen()
+            NavHost(
+                navController = navController,
+                startDestination = Overview.route,
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                composable(route = Overview.route) {
+                    Overview.screen()
+                }
+                composable(route = Accounts.route) {
+                    Accounts.screen()
+                }
+                composable(route = Bills.route) {
+                    Bills.screen()
+                }
             }
+
         }
     }
 }
+

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -71,63 +72,61 @@ fun RallyApp() {
                 )
             }
         ) { innerPadding ->
-            NavHost(
+            RallyNavHost(
                 navController = navController,
-                startDestination = Overview.route,
                 modifier = Modifier.padding(innerPadding)
-            ) {
-                composable(route = Overview.route) {
-                    OverviewScreen(
-                        onClickSeeAllAccounts = {
-                            navController.navigateSingleTopTo(Accounts.route)
-                        },
-                        onClickSeeAllBills = {
-                            navController.navigateSingleTopTo(Bills.route)
-                        },
-                        onAccountClick = { accountName ->
-                            navController.navigateToSingleAccount(accountName)
-                        }
-                    )
-                }
-                composable(route = Accounts.route) {
-                    AccountsScreen(
-                        onAccountClick = { accountType ->
-                            navController.navigateToSingleAccount(accountType)
-                        }
-                    )
-                }
-                composable(route = Bills.route) {
-                    BillsScreen()
-                }
-                composable(
-                    route = SingleAccount.routeWithArgs,
-                    arguments =  SingleAccount.arguments,
-                    deepLinks = SingleAccount.deepLinks
-                ) { navBackStackEntry ->
-                    // Retrieve the passed argument
-                    val accountType =
-                        navBackStackEntry.arguments?.getString(SingleAccount.accountTypeArg)
+            )
+        }
+    }
+}
 
-                    // Pass accountType to SingleAccountScreen
-                    SingleAccountScreen(accountType)
+@Composable
+fun RallyNavHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = Overview.route,
+        modifier = modifier
+    ) {
+        composable(route = Overview.route) {
+            OverviewScreen(
+                onClickSeeAllAccounts = {
+                    navController.navigateSingleTopTo(Accounts.route)
+                },
+                onClickSeeAllBills = {
+                    navController.navigateSingleTopTo(Bills.route)
+                },
+                onAccountClick = { accountType ->
+                    navController.navigateToSingleAccount(accountType)
                 }
-            }
-
+            )
+        }
+        composable(route = Accounts.route) {
+            AccountsScreen(
+                onAccountClick = { accountType ->
+                    navController.navigateToSingleAccount(accountType)
+                }
+            )
+        }
+        composable(route = Bills.route) {
+            BillsScreen()
+        }
+        composable(
+            route = SingleAccount.routeWithArgs,
+            arguments = SingleAccount.arguments,
+            deepLinks = SingleAccount.deepLinks
+        ) { navBackStackEntry ->
+            val accountType =
+                navBackStackEntry.arguments?.getString(SingleAccount.accountTypeArg)
+            SingleAccountScreen(accountType)
         }
     }
 }
 
 fun NavHostController.navigateSingleTopTo(route: String) =
-    this.navigate(route) {
-        popUpTo(
-            this@navigateSingleTopTo.graph.findStartDestination().id
-        ) {
-            saveState = true
-        }
-        launchSingleTop = true
-        restoreState = true
-    }
-
+    this.navigate(route) { launchSingleTop = true }
 
 private fun NavHostController.navigateToSingleAccount(accountType: String) {
     this.navigateSingleTopTo("${SingleAccount.route}/$accountType")

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -27,7 +27,10 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.*
+import com.example.compose.rally.ui.accounts.AccountsScreen
+import com.example.compose.rally.ui.bills.BillsScreen
 import com.example.compose.rally.ui.components.RallyTabRow
+import com.example.compose.rally.ui.overview.OverviewScreen
 import com.example.compose.rally.ui.theme.RallyTheme
 
 /**
@@ -70,13 +73,13 @@ fun RallyApp() {
                 modifier = Modifier.padding(innerPadding)
             ) {
                 composable(route = Overview.route) {
-                    Overview.screen()
+                    OverviewScreen()
                 }
                 composable(route = Accounts.route) {
-                    Accounts.screen()
+                    AccountsScreen()
                 }
                 composable(route = Bills.route) {
-                    Bills.screen()
+                    BillsScreen()
                 }
             }
 

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -29,6 +29,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import com.example.compose.rally.ui.accounts.AccountsScreen
 import com.example.compose.rally.ui.accounts.SingleAccountScreen
 import com.example.compose.rally.ui.bills.BillsScreen
@@ -100,7 +101,8 @@ fun RallyApp() {
                 }
                 composable(
                     route = SingleAccount.routeWithArgs,
-                    arguments =  SingleAccount.arguments
+                    arguments =  SingleAccount.arguments,
+                    deepLinks = SingleAccount.deepLinks
                 ) { navBackStackEntry ->
                     // Retrieve the passed argument
                     val accountType =

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyActivity.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.*
 import com.example.compose.rally.ui.components.RallyTabRow
 import com.example.compose.rally.ui.theme.RallyTheme
@@ -50,7 +52,10 @@ fun RallyApp() {
             topBar = {
                 RallyTabRow(
                     allScreens = rallyTabRowScreens,
-                    onTabSelected = { screen -> currentScreen = screen },
+                    onTabSelected = { newScreen ->
+                        navController
+                            .navigateSingleTopTo(newScreen.route)
+                    },
                     currentScreen = currentScreen
                 )
             }
@@ -75,3 +80,13 @@ fun RallyApp() {
     }
 }
 
+fun NavHostController.navigateSingleTopTo(route: String) =
+    this.navigate(route) {
+        popUpTo(
+            this@navigateSingleTopTo.graph.findStartDestination().id
+        ) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import com.example.compose.rally.ui.accounts.AccountsScreen
 import com.example.compose.rally.ui.accounts.SingleAccountScreen
 import com.example.compose.rally.ui.bills.BillsScreen
@@ -36,7 +37,6 @@ import com.example.compose.rally.ui.overview.OverviewScreen
 interface RallyDestination {
     val icon: ImageVector
     val route: String
-    val screen: @Composable () -> Unit
 }
 
 /**
@@ -45,19 +45,16 @@ interface RallyDestination {
 object Overview : RallyDestination {
     override val icon = Icons.Filled.PieChart
     override val route = "overview"
-    override val screen: @Composable () -> Unit = { OverviewScreen() }
 }
 
 object Accounts : RallyDestination {
     override val icon = Icons.Filled.AttachMoney
     override val route = "accounts"
-    override val screen: @Composable () -> Unit = { AccountsScreen() }
 }
 
 object Bills : RallyDestination {
     override val icon = Icons.Filled.MoneyOff
     override val route = "bills"
-    override val screen: @Composable () -> Unit = { BillsScreen() }
 }
 
 object SingleAccount : RallyDestination {
@@ -65,11 +62,13 @@ object SingleAccount : RallyDestination {
     // part of the RallyTabRow selection
     override val icon = Icons.Filled.Money
     override val route = "single_account"
-    override val screen: @Composable () -> Unit = { SingleAccountScreen() }
     const val accountTypeArg = "account_type"
     val routeWithArgs = "${route}/{${accountTypeArg}}"
     val arguments = listOf(
         navArgument(accountTypeArg) { type = NavType.StringType }
+    )
+    val deepLinks = listOf(
+        navDeepLink { uriPattern = "rally://$route/{$accountTypeArg}"}
     )
 }
 

--- a/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
+++ b/NavigationCodelab/app/src/main/java/com/example/compose/rally/RallyDestinations.kt
@@ -23,6 +23,8 @@ import androidx.compose.material.icons.filled.MoneyOff
 import androidx.compose.material.icons.filled.PieChart
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.example.compose.rally.ui.accounts.AccountsScreen
 import com.example.compose.rally.ui.accounts.SingleAccountScreen
 import com.example.compose.rally.ui.bills.BillsScreen
@@ -65,6 +67,10 @@ object SingleAccount : RallyDestination {
     override val route = "single_account"
     override val screen: @Composable () -> Unit = { SingleAccountScreen() }
     const val accountTypeArg = "account_type"
+    val routeWithArgs = "${route}/{${accountTypeArg}}"
+    val arguments = listOf(
+        navArgument(accountTypeArg) { type = NavType.StringType }
+    )
 }
 
 // Screens to be displayed in the top RallyTabRow


### PR DESCRIPTION
## Codelab Progress Tracking Pull Request
### Tasks checklist
- [x]  **Introduction**
- [x]  **Set up**
- [x]  **Overview of the Rally App**
- [x]  **Migration to Compose Navigation**
- [x]  **Integrate RallyTabRow with navigation**
- [x]  **Extracting screen composables from RallyDestinations**
- [x]  **Navigating to SingleAccountScreen with arguments**
- [x]  **Enable deep link support**
- [x]  **Extract the NavHost into RallyNavHost**
- [ ]  **Testing Compose Navigation**
- [x]  **Congratulations**

### Codelab Questions
1. How was navigation handled in the Rally app _before_ your codelab changes?
2. Where should the `NavController` be placed in the composable hierarchy of an Android application? Why?
3. What are some of the flags we can provide the `NavOptionsBuilder`, and how do they effect app behavior? In Step 5, there are several flags to try -- test a few of theme and explain the differences, using concepts like "back stack state" to make your explanations clear.
4. Explain how navigation arguments make the SingleAccountScreen able to display the correct information for different account types.
5. What are deep links? What are implicit deep links? What do you need to do to enable exposing deep links to external apps?

### Codelab Answers
1. Navigation existed, but it was awfully coded, using manual calls to the composable functions and Recomposing the screen entirely every time someone changed back 
2. We want the NavController sitting as close to the root of our app as possible, so we can pass navigation functions as callbacks further down as needed
3. One of the flags we use is the `launchSingleTop` flag, which ensures that there would only be one copy of a screen at the top of the back-stack. In other words, we can spam a navigation button a million times but it won't change more than the original. There's also `popUpTo(startDestination)` which helps us keep from a stack overflow, since we can soft-reset the app's stack with it to ensure we're not dozens of pages deep in an app.
4. The question's framed interestingly: The arguments don't make the app able in my mind, the abscence of them would make navigation impossible. There's some back-end mapping happening behind the scenes, and with callback functions and the NavHost, we can take the string of an indivual SingleAccount's name to determine what content the app is meant to render back, kind of like a Y shape where the NavHost takes information from one page, travels down the stem, and renders the correct page on the other end of the Y.
5. Deep Links are special links that help streamline a user to a very specific place within an app, bypassing things like the home page and navigation. A good example would be Spotify playlist links, that send you straight there regardless of where the app was originally. Implicit Deep Links do the same, but leave the actual navigation up to the OS to find where to go. My example is opening a reddit link in Chrome, asking if it wants to treat as a Chrome link or a Reddit Deep Link. Enabling deep links to our app requires defining those links in our app manifests, almost like express back doors where we have to design the inputs and the destination.
